### PR TITLE
Remove matchlog compression.

### DIFF
--- a/scripts/daily
+++ b/scripts/daily
@@ -8,4 +8,5 @@ docker-compose run --no-deps --entrypoint pg_dump run -h db -U robot -d robotgam
 # Note that -mtime +1 matches at least 2 days ago
 # Keep for 2 weeks so fewer 404s for Google
 docker-compose run --no-deps --entrypoint find run /matchlog/ -mtime +13 -delete;
-docker-compose run --no-deps --entrypoint find run /matchlog/ -not -path "/matchlog/" -not -path "*/.gitkeep" -not -name "*.gz" -exec gzip -6 "{}" \;
+# Do not compress.
+#docker-compose run --no-deps --entrypoint find run /matchlog/ -not -path "/matchlog/" -not -path "*/.gitkeep" -not -name "*.gz" -exec gzip -6 "{}" \;


### PR DESCRIPTION
This is a minor fix so that match logs can be properly served by nginx. From now on I'll try to keep the code deployed on the live server to be the same as the code in the latest release of rgserver.